### PR TITLE
Feature/fix crashpad init failure in samsung a20

### DIFF
--- a/util/net/http_transport_socket.cc
+++ b/util/net/http_transport_socket.cc
@@ -425,6 +425,7 @@ bool WriteRequest(Stream* stream,
                         sizeof(tmp),
                         "%08x",
                         base::checked_cast<unsigned int>(data_bytes));
+      (void)rv;
       DCHECK_EQ(static_cast<size_t>(rv), sizeof(buf.size));
       strncpy(buf.size, tmp, sizeof(buf.size));
       DCHECK_NE(buf.size[sizeof(buf.size) - 1], '\0');

--- a/util/posix/process_info_linux.cc
+++ b/util/posix/process_info_linux.cc
@@ -137,8 +137,13 @@ bool ProcessInfo::InitializeWithPtrace(PtraceConnection* connection) {
           while (AdvancePastNumber(&line_c, &group)) {
             supplementary_groups_.insert(group);
             if (!AdvancePastPrefix(&line_c, " ")) {
-              LOG(ERROR) << "format error: unrecognized Groups format";
-              return false;
+              // On some flavors of Android linux (i.e: in Samsung A20), the
+              // Groups: line does NOT have a trailing space. We should allow
+              // this.
+              if (strncmp(line_c, "\n", 1) != 0) {
+                LOG(ERROR) << "format error: unrecognized Groups format";
+                return false;
+              }
             }
           }
         }


### PR DESCRIPTION
**What?**
This fixes a Crashpad initialization failure which occurs in Samsung A20. 
**Why?**
The `Group:` line in the `/proc/<pid>/status` file does not have a trailing space, which breaks the Crashpad status file parser. 
**How?**
We relax the requirement that the `Group:` line in the `/proc` status file should have a trailing space.