### PR TITLE
Added the option to statically link against the MSVC runtime library …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 if (WIN32)
     enable_language(ASM_MASM)
+    option(STATIC_RUNTIME "Enable linking against the static MSVC runtime library" OFF)
 else ()
     enable_language(ASM)
 endif ()

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -52,9 +52,16 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(client STATIC ${CRASHPAD_CLIENT_LIBRARY_FILES})
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(client PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
 
 target_compile_features(client PUBLIC cxx_std_14)
 

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -45,6 +45,15 @@ if (WIN32)
     )
 endif (WIN32)
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_library(client STATIC ${CRASHPAD_CLIENT_LIBRARY_FILES})
 
 target_compile_features(client PUBLIC cxx_std_14)

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -59,10 +59,17 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(compat_incl INTERFACE)
 add_library(compat OBJECT)
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(compat PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
 
 target_sources(compat PRIVATE ${CRASHPAD_COMPAT_LIBRARY_FILES})
 target_link_libraries(compat PUBLIC util compat_incl)

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -52,6 +52,15 @@ if (WIN32)
     )
 endif (WIN32)
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_library(compat_incl INTERFACE)
 add_library(compat OBJECT)
 

--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -51,6 +51,9 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_executable(handler main.cc)

--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -44,6 +44,15 @@ if (ANDROID)
     )
 endif (ANDROID)
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_executable(handler main.cc)
 target_sources(handler PRIVATE ${CRASHPAD_HANDLER_LIBRARY_FILES})
 target_compile_features(handler PUBLIC cxx_std_17)

--- a/minidump/CMakeLists.txt
+++ b/minidump/CMakeLists.txt
@@ -61,9 +61,17 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(minidump OBJECT ${CRASHPAD_MINIDUMP_LIBRARY_FILES})
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(minidump PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
+
 target_compile_features(minidump PUBLIC cxx_std_14)
 target_include_directories(minidump PRIVATE ..)
 target_link_libraries(minidump PUBLIC mini_chromium compat)

--- a/minidump/CMakeLists.txt
+++ b/minidump/CMakeLists.txt
@@ -54,6 +54,15 @@ set(CRASHPAD_MINIDUMP_LIBRARY_FILES
     ./minidump_writer_util.h
 )
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_library(minidump OBJECT ${CRASHPAD_MINIDUMP_LIBRARY_FILES})
 target_compile_features(minidump PUBLIC cxx_std_14)
 target_include_directories(minidump PRIVATE ..)

--- a/snapshot/CMakeLists.txt
+++ b/snapshot/CMakeLists.txt
@@ -173,9 +173,16 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(snapshot OBJECT ${CRASHPAD_SNAPSHOT_LIBRARY_FILES})
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(snapshot PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
 
 if (ANDROID)
     target_compile_features(snapshot PUBLIC cxx_std_17)

--- a/snapshot/CMakeLists.txt
+++ b/snapshot/CMakeLists.txt
@@ -166,6 +166,15 @@ if (WIN32)
     )
 endif (WIN32)
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_library(snapshot OBJECT ${CRASHPAD_SNAPSHOT_LIBRARY_FILES})
 
 if (ANDROID)

--- a/third_party/getopt/CMakeLists.txt
+++ b/third_party/getopt/CMakeLists.txt
@@ -3,6 +3,15 @@ set(CRASHPAD_GETOPT_LIBRARY_FILES
     getopt.h
 )
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_library(crashpad_getopt OBJECT)
 target_sources(crashpad_getopt PRIVATE
     ${CRASHPAD_GETOPT_LIBRARY_FILES})

--- a/third_party/getopt/CMakeLists.txt
+++ b/third_party/getopt/CMakeLists.txt
@@ -10,9 +10,17 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(crashpad_getopt OBJECT)
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(crashpad_getopt PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
+
 target_sources(crashpad_getopt PRIVATE
     ${CRASHPAD_GETOPT_LIBRARY_FILES})
 target_compile_features(crashpad_getopt PUBLIC cxx_std_14)

--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -123,9 +123,17 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(mini_chromium OBJECT ${CRASHPAD_MINI_CHROMIUM_LIBRARY_FILES})
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(mini_chromium PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
+
 target_compile_features(mini_chromium PUBLIC cxx_std_14)
 target_include_directories(mini_chromium PUBLIC mini_chromium)
 

--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -116,6 +116,15 @@ if (WIN32)
     )
 endif (WIN32)
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_library(mini_chromium OBJECT ${CRASHPAD_MINI_CHROMIUM_LIBRARY_FILES})
 target_compile_features(mini_chromium PUBLIC cxx_std_14)
 target_include_directories(mini_chromium PUBLIC mini_chromium)

--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -44,12 +44,20 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(zlib STATIC)
 target_sources(zlib PRIVATE
     ${CRASHPAD_ZLIB_LIBRARY_FILES}
 )
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(zlib PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
+
 target_compile_features(zlib PUBLIC cxx_std_14)
 
 target_compile_definitions(zlib PUBLIC CRASHPAD_ZLIB_SOURCE_EMBEDDED)

--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -37,6 +37,15 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "(x86_64)|(AMD64)")
     )
 endif ()
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_library(zlib STATIC)
 target_sources(zlib PRIVATE
     ${CRASHPAD_ZLIB_LIBRARY_FILES}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,9 +10,17 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(tools OBJECT ${CRASHPAD_TOOLS_LIBRARY_FILES})
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(tools PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
+
 target_compile_features(tools PUBLIC cxx_std_14)
 
 target_include_directories(tools PUBLIC ..)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,6 +3,15 @@ set(CRASHPAD_TOOLS_LIBRARY_FILES
     ./tool_support.h
 )
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
+
 add_library(tools OBJECT ${CRASHPAD_TOOLS_LIBRARY_FILES})
 target_compile_features(tools PUBLIC cxx_std_14)
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -309,6 +309,14 @@ if (WIN32)
     endif ()
 endif (WIN32)
 
+if (WIN32 AND STATIC_RUNTIME)
+    add_compile_options(
+        $<$<CONFIG:Debug>:/MTd>
+        $<$<CONFIG:MinSizeRel>:/MT>
+        $<$<CONFIG:Release>:/MT>
+        $<$<CONFIG:RelWithDebInfo>:/MT>
+    )
+endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(util OBJECT ${CRASHPAD_UTIL_LIBRARY_FILES})
 target_compile_features(util PUBLIC cxx_std_17)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -316,9 +316,17 @@ if (WIN32 AND STATIC_RUNTIME)
         $<$<CONFIG:Release>:/MT>
         $<$<CONFIG:RelWithDebInfo>:/MT>
     )
+    add_compile_definitions(
+        $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
+    )
 endif (WIN32 AND STATIC_RUNTIME)
 
 add_library(util OBJECT ${CRASHPAD_UTIL_LIBRARY_FILES})
+
+if (WIN32 AND STATIC_RUNTIME)
+    set_target_properties(util PROPERTIES STATIC_LIBRARY_OPTIONS "/NODEFAULTLIB;")
+endif (WIN32 AND STATIC_RUNTIME)
+
 target_compile_features(util PUBLIC cxx_std_17)
 
 if (APPLE)


### PR DESCRIPTION
…by using the -DSTATIC_RUNTIME=ON argument passed to the cmake generator command.