### PR TITLE
linux: implement missing CrashpadClient::IsSafeModeRequired.

### DIFF
--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -144,12 +144,13 @@ class CrashpadClient {
   //! \return `true` on success. Otherwise `false` with a message logged.
   bool EnableCrashLoopDetection();
 
-  //! \brief Detects the number of the consecutive crashing runs
+  //! \brief Detects if safe mode should be enabled
   //!
-  //! This function reads the crash database and counts the number of last
-  //! consecutive runs having crashed.
+  //! This function uses a heuristic to determine whether it makes sense to
+  //! require the safe mode. Currently it only looks at the number of
+  //! consecutive crashes.
   //!
-  //! \return number of logged errors on success. Otherwise `-1`.
+  //! \return `true` if safe mode is required, `false` otherwise
   static bool IsSafeModeRequired(const base::FilePath& database);
 
   //! \brief Detects the number of the consecutive crashing runs

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -489,6 +489,11 @@ bool CrashpadClient::EnableCrashLoopDetection()
   return crash_loop_detection_;
 }
 
+bool CrashpadClient::IsSafeModeRequired(const base::FilePath& database)
+{
+  return ConsecutiveCrashesCount(database) >= 5;
+}
+
 int CrashpadClient::ConsecutiveCrashesCount(const base::FilePath& database)
 {
   namespace clc = backtrace::crash_loop_detection;


### PR DESCRIPTION
This function was missing implementation in crash loop detection 1.0 by a mistake. This commit fixes that.