### PR TITLE
linux: add guid override functionality.

### DIFF
--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -162,6 +162,18 @@ class CrashpadClient {
   static int ConsecutiveCrashesCount(const base::FilePath& database);
 #endif
 
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX) || DOXYGEN
+  //! \brief Enable the use of a GUID override.
+  //!
+  //! This function must be called prior to `StartHandler()`
+  //!
+  //! \param[in] uuid The GUID to use as the GUID.
+  //!
+  //! \return `true` on success. Otherwise `false` with a message logged.
+  bool OverrideGuid(const std::string& uuid);
+  bool OverrideGuid(const UUID& uuid);
+#endif // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX) || DOXYGEN
+
 #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || \
     DOXYGEN
   //! \brief Retrieve the socket and process ID for the handler.
@@ -845,6 +857,10 @@ class CrashpadClient {
   UUID run_uuid_;
   std::set<int> unhandled_signals_;
 #endif  // BUILDFLAG(IS_APPLE)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
+  bool uuid_override_enabled_ = false;
+  UUID uuid_override_;
+#endif // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 };
 
 }  // namespace crashpad

--- a/examples/linux/demo/demo.cpp
+++ b/examples/linux/demo/demo.cpp
@@ -53,7 +53,11 @@ startCrashHandler(std::string const& url, std::string const& handler_path,
     /* Enable automated uploads. */
     database->GetSettings()->SetUploadsEnabled(true);
 
-    return CrashpadClient{}.StartHandler(
+    CrashpadClient client{};
+
+    client.OverrideGuid("11111111-2222-3333-4444-555555555555");
+
+    return client.StartHandler(
         handler, db, db, url, annotations, arguments, false, false, {}
     );
 }

--- a/handler/minidump_to_upload_parameters.cc
+++ b/handler/minidump_to_upload_parameters.cc
@@ -77,9 +77,16 @@ std::map<std::string, std::string> BreakpadHTTPFormParametersFromMinidump(
     InsertOrReplaceMapEntry(&parameters, "list_annotations", list_annotations);
   }
 
-  UUID client_id;
-  process_snapshot->ClientID(&client_id);
-  InsertOrReplaceMapEntry(&parameters, "guid", client_id.ToString());
+  if (parameters.count("_backtrace_internal_guid_override")) {
+    InsertOrReplaceMapEntry(&parameters,
+                            "guid",
+                            parameters.at("_backtrace_internal_guid_override"));
+    parameters.erase("_backtrace_internal_guid_override");
+  } else {
+    UUID client_id;
+    process_snapshot->ClientID(&client_id);
+    InsertOrReplaceMapEntry(&parameters, "guid", client_id.ToString());
+  }
 
   return parameters;
 }


### PR DESCRIPTION
This change allows the user to use the `EnableGuidOverride()` function to override GUID of a report. This is useful for matching native reports with managed ones.