### PR TITLE
crashpad/android: crash loop detection, guid override

### DIFF
--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -856,10 +856,19 @@ class CrashpadClient {
   bool crash_loop_detection_ = false;
   UUID run_uuid_;
   std::set<int> unhandled_signals_;
+
+  // Append the necessary annotation to the crash handler arguments if crash loop detection is
+  // enabled.
+  void MaybeAppendCrashLoopDetectionArgs(const base::FilePath& database,
+                                         std::vector<std::string> *handler_args);
 #endif  // BUILDFLAG(IS_APPLE)
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
   bool uuid_override_enabled_ = false;
   UUID uuid_override_;
+
+  // Append the necessary annotation to the crash handler arguments if the GUID was overriden
+  // by `OverrideGuid`.
+  void MaybeAppendUuidOverrideArgs(std::vector<std::string> *handler_args);
 #endif // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 };
 

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -666,6 +666,8 @@ bool CrashpadClient::StartJavaHandlerAtCrash(
                                                       annotations,
                                                       arguments,
                                                       kInvalidFileHandle);
+  MaybeAppendCrashLoopDetectionArgs(database, &argv);
+  MaybeAppendUuidOverrideArgs(&argv);
 
   auto signal_handler = LaunchAtCrashHandler::Get();
   return signal_handler->Initialize(&argv, env, &unhandled_signals_);


### PR DESCRIPTION
While updating backtrace-android to use `StartJavaHandlerAtCrash` it was noticed that arguments for crash loop detection and guid override were not being passed through to the crashed handler.

This commit adds these arguments in `StartJavaHandlerAtCrash` to support these features when using this Android-specific mechanism and are of the form:

 * for crash loop detection: `--annotation=run-uuid=`
 * for guid override: `--annotation=_backtrace_internal_guid_override=`

Internal ref BT-2929