### PR TITLE
crashpad/tests: run only arm64 tests on macOS; skip x86_64

### DIFF
--- a/backtrace/test/test.rb
+++ b/backtrace/test/test.rb
@@ -2,7 +2,8 @@
 
 require 'minitest/autorun'
 require 'os'
+require 'rbconfig'
 
 require_relative 'test_linux' if OS.linux?
-require_relative 'test_macos' if OS.mac?
+require_relative 'test_macos' if OS.mac? && RbConfig::CONFIG['host_cpu'] == 'arm64'
 require_relative 'test_windows' if OS.windows?


### PR DESCRIPTION
Presently, tests run for macOS/x64_64 hang when run as a gitlab job. As there is still macOS coverage, as arm64, disable the x64_64 tests on macOS, for now, until we have time to properly investigate.