### PR TITLE
build: fix linux/android builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -150,7 +150,7 @@ jobs:
           path: Crashpad_MacOs_build_${{ matrix.arch }}.zip
 
   build-android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Rather than use ubuntu:latest (presently, ubuntu:noble) use the oldest
supported version of Ubuntu for maximum compatibility (earliest glib
version, etc.) and for addressing build issues. The earliest supported
version available as a github runner at this time is ubuntu-20.04.

This was done in response to a build issue in the mini_chromium directory
where the header stdint.h needs to be included. This is addressed in later
versions of the submodule (eb418ec05f) and will get picked when this fork
is sync'd with upstream. This isn't a problem in earlier versions of GCC
because the header is implicitly included.

There were also permission issues updating ruby bundles in Ubuntu Noble
that this change works around.