### PR TITLE
Fix Darwin Universal build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,10 @@ jobs:
       matrix:
         arch: [arm64, x86_64]
         generator: ["Unix Makefiles", Ninja]
+        include:
+          - arch: "arm64;x86_64"
+            generator: Ninja
+            arch_name: universal
 
     steps:
       # Install latest CMake.
@@ -128,10 +132,18 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set arch name
+        run: |
+          if [ -z "${{ matrix.arch_name }}" ]; then
+            echo "arch_name=${{ matrix.arch }}" >> $GITHUB_ENV
+          else
+            echo "arch_name=${{ matrix.arch_name }}" >> $GITHUB_ENV
+          fi
+
       - name: CMake
         run: |
           mkdir cbuild
-          cmake -S . -B cbuild/ -DCRASHPAD_BUILD_EXAMPLES=TRUE -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) -G "${{ matrix.generator }}"
+          cmake -S . -B cbuild/ -DCRASHPAD_BUILD_EXAMPLES=TRUE "-DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}" -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) -G "${{ matrix.generator }}"
           cmake --build cbuild/
 
       - uses: ruby/setup-ruby@v1
@@ -142,12 +154,12 @@ jobs:
 
       - name: Crashpad distribution ZIP
         run: |
-          ruby backtrace/save_artifacts.rb --output Crashpad_MacOs_build_${{ matrix.arch }}.zip
+          ruby backtrace/save_artifacts.rb --output Crashpad_MacOs_build_${{ env.arch_name }}.zip
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Crashpad_MacOs_build_${{ matrix.arch }}_${{ matrix.generator }}_${{ github.sha }}
-          path: Crashpad_MacOs_build_${{ matrix.arch }}.zip
+          name: Crashpad_MacOs_build_${{ env.arch_name }}_${{ matrix.generator }}_${{ github.sha }}
+          path: Crashpad_MacOs_build_${{ env.arch_name }}.zip
 
   build-android:
     runs-on: ubuntu-22.04

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -377,18 +377,24 @@ if (APPLE)
             list(APPEND OUTPUT_FILES "${OUTPUT_PATH}/${BASE_NAME}${SUFFIX}")
         endforeach()
 
-        if (${CMAKE_OSX_ARCHITECTURES})
-            set(MIG_ARCH ${CMAKE_OSX_ARCHITECTURES})
+        if(CMAKE_OSX_ARCHITECTURES)
+            set(OSX_ARCHITECTURES ${CMAKE_OSX_ARCHITECTURES})
         else()
-            set(MIG_ARCH "arm64")
+            set(OSX_ARCHITECTURES ${CMAKE_SYSTEM_PROCESSOR})
         endif()
+
+        set(MIG_ARCH)
+        foreach(ARCH ${OSX_ARCHITECTURES})
+            list(APPEND MIG_ARCH "--arch")
+            list(APPEND MIG_ARCH ${ARCH})
+        endforeach()
 
         add_custom_command(
             OUTPUT
                 ${OUTPUT_FILES}
             COMMAND
                 "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mach/mig.py"
-                    "--arch" ${MIG_ARCH}
+                    ${MIG_ARCH}
                     "--sdk" ${CMAKE_OSX_SYSROOT}
                     "--include=${CMAKE_CURRENT_SOURCE_DIR}/.."
                     "--include=${CMAKE_CURRENT_SOURCE_DIR}/../compat/mac"


### PR DESCRIPTION
Properly use mig generator for Universal builds,
e.g. when CMAKE_OSX_ARCHITECTURES=x86_64;arm64