### PR TITLE
crashpad: linux: implement dynamic attachments for single use handlers

### DIFF
--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -531,6 +531,14 @@ class CrashpadClient {
   //!
   //! \param[in] unhandled_signals The set of unhandled signals
   void SetUnhandledSignals(const std::set<int>& unhandled_signals);
+
+  //! \brief Add an additional attachment to be submitted along with any crash
+  //! report.
+  //!
+  //! This can be called after initialization of any single use handler. This
+  //! includes |StartJavaHandlerAtCrash|, |StartHandlerWithLinkerAtCrash|, or
+  //! |StartHandlerAtCrash|.
+  void AddAttachment(const std::string& attachment);
 #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID) ||
         // BUILDFLAG(IS_CHROMEOS) || DOXYGEN
 

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -335,6 +335,12 @@ class LaunchAtCrashHandler : public SignalHandler {
     waitpid(pid, &status, 0);
   }
 
+  void PushArgument(std::string arg)
+  {
+     argv_strings_.push_back(arg);
+     StringVectorToCStringVector(argv_strings_, &argv_);
+  }
+
  private:
   LaunchAtCrashHandler() = default;
 
@@ -845,5 +851,12 @@ void CrashpadClient::SetCrashLoopBefore(uint64_t crash_loop_before_time) {
   request_crash_dump_handler->SetCrashLoopBefore(crash_loop_before_time);
 }
 #endif
+
+void CrashpadClient::AddAttachment(const std::string& attachment) {
+  auto signal_handler = LaunchAtCrashHandler::Get();
+
+  signal_handler->PushArgument(
+    base::StringPrintf("--attachment=%s", attachment.c_str()));
+}
 
 }  // namespace crashpad


### PR DESCRIPTION
When integrating with backtrace-android it was noticed that file attachments can only be configured during initialization of the Backtrace client.

There is a need, however, to allow specifying additional attachments after initialization (e.g., an attachment with a name unknown until runtime, like a generated screenshot).

This commit allows adding additional attachments after initialization for specific use cases.

Note that the scope of this change is intentionally small and is limited to the Linux client (Linux, Andriod, or ChromeOS) and only for single use handlers; i.e., those for which the handler is run upon crash. This allows appending arguments to pass to the handler prior to any crash and avoids having to modify the CrashpadInfo structure, for the time being.