### PR TITLE
ci(android): set up Ruby before building the distribution zip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,6 +187,14 @@ jobs:
           cmake -S . -B cbuild/ -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/${{ matrix.ndk }}/build/cmake/android.toolchain.cmake -DANDROID_ABI=${{ matrix.abi }} -DANDROID_PLATFORM=android-${{ matrix.apiLevel }} -DANDROID_NATIVE_API_LEVEL=${{ matrix.apiLevel }} -DANDROID_TOOLCHAIN=clang -DCRASHPAD_HTTPS_TRANSPORT=${{ env.SSL_MODE }} -DCRASHPAD_BUILD_EXAMPLES=TRUE
           cmake --build cbuild/
 
+      # save_artifacts.rb installs gems through bundler/inline, which needs a
+      # user-managed Ruby/Bundler. The other platforms get this from
+      # ruby/setup-ruby; the Android job was missing it and broke once the
+      # runner's pre-installed Ruby could no longer install the zip gem.
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+
       - name: Crashpad distribution ZIP
         run: |
           ruby backtrace/save_artifacts.rb --output Crashpad_Android_ndk${{ matrix.ndk }}_apiLevel${{ matrix.apiLevel }}_${{ matrix.abi }}_build.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,10 +187,8 @@ jobs:
           cmake -S . -B cbuild/ -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/${{ matrix.ndk }}/build/cmake/android.toolchain.cmake -DANDROID_ABI=${{ matrix.abi }} -DANDROID_PLATFORM=android-${{ matrix.apiLevel }} -DANDROID_NATIVE_API_LEVEL=${{ matrix.apiLevel }} -DANDROID_TOOLCHAIN=clang -DCRASHPAD_HTTPS_TRANSPORT=${{ env.SSL_MODE }} -DCRASHPAD_BUILD_EXAMPLES=TRUE
           cmake --build cbuild/
 
-      # save_artifacts.rb installs gems through bundler/inline, which needs a
-      # user-managed Ruby/Bundler. The other platforms get this from
-      # ruby/setup-ruby; the Android job was missing it and broke once the
-      # runner's pre-installed Ruby could no longer install the zip gem.
+      # save_artifacts.rb installs gems through bundler/inline, which needs a user-managed Ruby/Bundler.
+      # The other platforms get this from ruby/setup-ruby.
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"


### PR DESCRIPTION
## Summary

The build-android jobs run backtrace/save_artifacts.rb, which installs the zip gem via bundler/inline. 
Unlike the Linux/Windows/macOS jobs, the Android job had no ruby/setup ruby step and relied on the runner's pre installed Ruby.

After a GitHub-hosted ubuntu-22.04 image update (~2026-06-10) that Ruby could no longer install the gem, so the "Crashpad distribution ZIP" step started failing on every Android matrix cell while all other platforms passed.

## Changes
Add ruby/setup-ruby@v1 (Ruby 3.1) before the ZIP step, matching the other platforms, so bundler/inline runs against a user managed Ruby/Bundler.


ref: BT-7241